### PR TITLE
Add CLI option to allow for ordered prompts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ python3 recorder.py -p prompts/timit.txt
 
 ```
 usage: recorder.py [-h] [-p PROMPTS_FILENAME] [-d SAVE_DIR] [-c PROMPTS_COUNT]
-                   [-l PROMPT_LEN_SOFT_MAX]
+                   [-l PROMPT_LEN_SOFT_MAX] [-o]
 
 Given a text file containing prompts, this app will choose a random selection
 and ordering of them, display them to be dictated by the user, and record the
@@ -46,6 +46,8 @@ optional arguments:
   -c PROMPTS_COUNT, --prompts_count PROMPTS_COUNT
                         number of prompts to select and display (default: 100)
   -l PROMPT_LEN_SOFT_MAX, --prompt_len_soft_max PROMPT_LEN_SOFT_MAX
+  -o, --ordered         present prompts in order, as opposed to random
+                        (default: False)
 ```
 
 ## Customization


### PR DESCRIPTION
By default, the recorder presents the same prompt multiple times.  I don't know much about how the training works yet, so my gut tells me that having multiple audio files for the same prompt might cause problems.  Then my brain tells me that it might actually be good for training.  Since I have no idea, I'm going with my gut for now.  :laughing: 

I'm probably overthinking this, so please close if this is a bad idea.